### PR TITLE
Restore overlayManager tracking on ElegantNotification.show

### DIFF
--- a/lib/elegant_notification.dart
+++ b/lib/elegant_notification.dart
@@ -395,6 +395,8 @@ class ElegantNotification extends StatefulWidget {
     } else {
       Navigator.of(context).overlay?.insert(overlayEntry!);
     }
+
+    overlayManager.addOverlay(internalKey, overlayEntry!);
   }
 
   void closeOverlay() {


### PR DESCRIPTION
Proposed fix to allow use of Navigator's overlay misplaced the line that added the overlay to the overlayManager. This PR adds this line back in, which also fixes notification stacking.